### PR TITLE
Fixed issues with grading not updating or displaying correctly.

### DIFF
--- a/classes/local/grade_helpers.php
+++ b/classes/local/grade_helpers.php
@@ -253,22 +253,21 @@ class grade_helpers {
 
             } else {
 
-                $nograde = [0 => get_string('cmi5launchnogradeerror', 'cmi5launch')];
-                // Do nothing, there is no record for this user in this course.
+                // No record for this user in this course yet, return null (no grade).
                 // Restore default hadlers.
                 restore_exception_handler();
                 restore_error_handler();
-                return $nograde;
+                return null;
 
             }
         } catch (\Throwable $e) {
 
-            // If there is an error, return the error.
+            // If there is an error, log it and return null so gradebook is not set to error.
             echo(get_string('cmi5launchgradeerror', 'cmi5launch') . $e->getMessage());
             // Restore default hadlers.
             restore_exception_handler();
             restore_error_handler();
-            return $e;
+            return null;
         }
     }
 
@@ -297,6 +296,10 @@ class grade_helpers {
         // Array to hold AU scores.
         $auscores = [];
         $overallgrade = [];
+        // Collect all AU grades to compute overall.
+        $augrades = [];
+        // Determine gradetype once outside the loop.
+        $gradetype = $cmi5launchsettings["grademethod"];
         try {
             // Bring in functions and classes.
             $sessionhelper = $sessionhelpers;
@@ -354,9 +357,7 @@ class grade_helpers {
                         // Save the session scores to AU, it is ok to overwrite.
                         $aurecord->scores = json_encode($sessiongrades, JSON_NUMERIC_CHECK);
 
-                        // Determine gradetype and use it to save overall grade to AU.
-                        $gradetype = $cmi5launchsettings["grademethod"];
-
+                        // Use gradetype (set outside loop) to save overall grade to AU.
                         switch ($gradetype) {
 
                             // GRADE_AUS_CMI5 = 0.
@@ -378,14 +379,28 @@ class grade_helpers {
                         // Save AU scores to corresponding title.
                         $auscores[$aurecord->lmsid] = [$aurecord->title => $aurecord->scores];
 
-                        // Save an overall grade \to be passed out to grade_update.
-                        $overallgrade = $aurecord->grade;
+                        // Collect this AU's grade to compute overall after all AUs are processed.
+                        $augrades[] = $aurecord->grade;
 
                         // Save Au title and their scores to AU.
                         // Save updates to DB.
                         $aurecord = $DB->update_record('cmi5launch_aus', $aurecord);
 
                     }
+                }
+            }
+
+            // Compute overall grade across all AUs using the grade method.
+            if (!empty($augrades)) {
+                switch ($gradetype) {
+                    case 1:
+                        $overallgrade = $this->cmi5launch_highest_grade($augrades);
+                        break;
+                    case 2:
+                        $overallgrade = $this->cmi5launch_average_grade($augrades);
+                        break;
+                    default:
+                        $overallgrade = 0;
                 }
             }
 

--- a/grade.php
+++ b/grade.php
@@ -90,7 +90,9 @@ if (has_capability('mod/cmi5launch:viewgrades', $context)) {
     foreach ($users as $user) {
 
         // Call updategrades to ensure all grades are up to date before view.
-        cmi5launch_update_grades($cm, $user->id);
+        // Must pass $cmi5launch (instance), not $cm (course module) — passing $cm would use $cm->id
+        // as the grade item instance, creating a duplicate grade item in the gradebook.
+        cmi5launch_update_grades($cmi5launch, $user->id);
     }
 
     // If the logged in user has an id pass that along, as they may have grades to view as well.

--- a/lang/en/cmi5launch.php
+++ b/lang/en/cmi5launch.php
@@ -429,8 +429,10 @@ $string['cmi5launchscore'] = 'Score';
 $string['cmi5launchsessionaucompleted'] = 'Completed';
 $string['cmi5launchsessionaucompletedpassed'] = 'Completed and Passed';
 $string['cmi5launchsessionaucompletedfailed'] = 'Completed and Failed';
+$string['cmi5launchsessiongradeaus'] = 'AU';
 $string['cmi5launchsessiongradehigh'] = 'Highest';
 $string['cmi5launchsessiongradeaverage'] = 'Average';
+$string['cmi5launchsessiongradesum'] = 'Sum';
 
 // For view.php.
 $string['cmi5launchviewcourseerror'] = 'Creating or retrieving user course record. Contact your system administrator with error: ';

--- a/lib.php
+++ b/lib.php
@@ -724,6 +724,103 @@ function cmi5launch_settings($instance) {
 // Grade functions.
 
 /**
+ * Called when grademethod admin setting changes.
+ * Recalculates grades for all enrolled users across all cmi5launch instances
+ * using stored session scores (no LRS/player API calls) and pushes the result
+ * directly to Moodle's gradebook so the native grader reflects the change immediately.
+ */
+function cmi5launch_grade_item_force_regrading() {
+    global $DB, $CFG, $cmi5launchsettings;
+
+    require_once($CFG->libdir . '/gradelib.php');
+
+    // Reset the settings cache so cmi5launch_settings() re-reads the newly saved grademethod.
+    $cmi5launchsettings = null;
+
+    $instances = $DB->get_records('cmi5launch');
+    foreach ($instances as $instance) {
+
+        // Read fresh settings (including the new grademethod).
+        $settings  = cmi5launch_settings($instance->id);
+        $gradetype = (int)$settings['grademethod'];
+
+        // Need the course module to enumerate enrolled users.
+        $cm = get_coursemodule_from_instance('cmi5launch', $instance->id, $instance->course,
+            false, IGNORE_MISSING);
+        if (!$cm) {
+            continue;
+        }
+        $context = context_module::instance($cm->id);
+        $users   = get_enrolled_users($context);
+
+        foreach ($users as $user) {
+
+            // Stored session scores live in cmi5launch_usercourse.ausgrades — no LRS call needed.
+            $usercourse = $DB->get_record('cmi5launch_usercourse',
+                ['courseid' => $instance->courseid, 'userid' => $user->id]);
+            if (!$usercourse || empty($usercourse->ausgrades)) {
+                continue;
+            }
+
+            $ausgrades = json_decode($usercourse->ausgrades, true);
+            if (empty($ausgrades)) {
+                continue;
+            }
+
+            // For each AU, apply grademethod to its session scores to get an AU grade.
+            $augrades = [];
+            foreach ($ausgrades as $lmsid => $audata) {
+                foreach ($audata as $title => $scoresjson) {
+                    $scores = json_decode($scoresjson, true);
+                    if (empty($scores) || !is_array($scores)) {
+                        continue;
+                    }
+                    $scores = array_filter($scores, 'is_numeric');
+                    if (empty($scores)) {
+                        continue;
+                    }
+                    switch ($gradetype) {
+                        case 1:
+                            $augrades[] = (float)max($scores);
+                            break;
+                        case 2:
+                            $augrades[] = (float)(array_sum($scores) / count($scores));
+                            break;
+                    }
+                }
+            }
+
+            if (empty($augrades)) {
+                continue;
+            }
+
+            // Apply grademethod across AU grades to get the overall course grade.
+            switch ($gradetype) {
+                case 1:
+                    $overallgrade = max($augrades);
+                    break;
+                case 2:
+                    $overallgrade = array_sum($augrades) / count($augrades);
+                    break;
+                default:
+                    continue 2;
+            }
+
+            // Push the recalculated grade directly to Moodle's gradebook.
+            $grade           = new stdClass();
+            $grade->userid   = $user->id;
+            $grade->rawgrade = round((float)$overallgrade, 2);
+
+            grade_update('mod/cmi5launch', $instance->course, 'mod', 'cmi5launch',
+                $instance->id, 0, $grade);
+        }
+
+        // Reset cache between instances so each gets its own fresh settings lookup.
+        $cmi5launchsettings = null;
+    }
+}
+
+/**
  * Return grade for given user or all users.
  * @param stdClass $cmi5launch The Cmi5 mod instance object.
  * @param int $userid Optional user id, 0 means all users.
@@ -738,8 +835,10 @@ function cmi5launch_get_user_grades($cmi5launch, $userid=0) {
 
     global $CFG, $DB;
 
-    $id = required_param('id', PARAM_INT);
-    $contextmodule = context_module::instance($id);
+    // Derive the course module from the instance so this function works when called
+    // by Moodle's gradebook framework (which has no 'id' URL param).
+    $cm = get_coursemodule_from_instance('cmi5launch', $cmi5launch->id, $cmi5launch->course, false, MUST_EXIST);
+    $contextmodule = context_module::instance($cm->id);
 
     $grades = [];
 
@@ -796,11 +895,10 @@ function cmi5launch_update_grades($cmi5launch, $userid = 0, $nullifnone = true) 
 
     require_once($CFG->libdir . '/gradelib.php');
     require_once($CFG->libdir . '/completionlib.php');
-    $id = required_param('id', PARAM_INT);
 
-    // Reload cmi5 course instance.
-    $record = $DB->get_record('cmi5launch', ['id' => $cmi5launch->id]);
-    $cm = get_coursemodule_from_id('cmi5launch', $id, 0, false, MUST_EXIST);
+    // Derive the course module from the instance so this function works when called
+    // by Moodle's gradebook framework (which has no 'id' URL param).
+    $cm = get_coursemodule_from_instance('cmi5launch', $cmi5launch->id, $cmi5launch->course, false, MUST_EXIST);
     $contextmodule = context_module::instance($cm->id);
     $users = get_enrolled_users($contextmodule);
 
@@ -825,7 +923,17 @@ function cmi5launch_update_grades($cmi5launch, $userid = 0, $nullifnone = true) 
 
     } else {
 
-        cmi5launch_grade_item_update($cmi5launch);
+        // Update grades for all enrolled users.
+        if ($users) {
+            foreach ($users as $user) {
+                $grades = cmi5launch_get_user_grades($cmi5launch, $user->id);
+                if ($grades && isset($grades[$user->id])) {
+                    cmi5launch_grade_item_update($cmi5launch, $grades[$user->id]);
+                }
+            }
+        } else {
+            cmi5launch_grade_item_update($cmi5launch);
+        }
     }
 }
 
@@ -875,14 +983,17 @@ function cmi5launch_grade_item_update($cmi5launch, $grades = null) {
     $params['grademax'] = $maxgrade;
     $params['grademin'] = 0;
 
-    // If there's a max grade, set it.
+    // Always use GRADE_TYPE_VALUE (1) for the Moodle grade item type.
+    // $gradetype is the CMI5 grade method (1=highest, 2=average) — NOT a Moodle grade type constant.
+    // Passing $gradetype directly would cause average (=2) to create a GRADE_TYPE_SCALE item,
+    // which cannot store float scores and shows 'error' in the gradebook.
     if ($maxgrade) {
-        $params['gradetype'] = $gradetype;
+        $params['gradetype'] = GRADE_TYPE_VALUE;
         $params['grademax'] = $maxgrade;
         $params['grademin'] = 0;
     } else {
 
-        $params['gradetype'] = $gradetype;
+        $params['gradetype'] = GRADE_TYPE_VALUE;
     }
 
     // Check if it's call to reset.

--- a/report.php
+++ b/report.php
@@ -144,8 +144,9 @@ if (has_capability('mod/cmi5launch:viewgrades', $context)) {
 
     foreach ($users as $user) {
 
-        // Call updategrades to ensure all grades are up to date before view.
-        $updategrades($user);
+        // Call updategrades to ensure all grades are up to date before view,
+        // and push the updated grade to Moodle's gradebook.
+        cmi5launch_update_grades($cmi5launch, $user->id);
 
         // Each user needs their own column.
         $headers[] = $user->username;
@@ -161,8 +162,8 @@ if (has_capability('mod/cmi5launch:viewgrades', $context)) {
     // Retrieve that user from DB.
     $user = $DB->get_record('user', ['id' => $USER->id]);
 
-    // Make sure their grades are up to date.
-    $updategrades($user);
+    // Make sure their grades are up to date and push to Moodle's gradebook.
+    cmi5launch_update_grades($cmi5launch, $user->id);
     // Add user to array for processing, the table build expects an array of users with their id as their index.
     $users[$user->id] = $user;
 

--- a/session_report.php
+++ b/session_report.php
@@ -195,8 +195,9 @@ foreach ($auids as $key => $auid) {
                 }
                 
                 // The users sessions.
+                // Use $cmi5launch->id (activity instance ID), not $id (cm ID) — sessions are stored with the instance ID.
                 $usersession = $DB->get_record('cmi5launch_sessions',
-                    ['sessionid' => $sessionid, 'userid' => $userid, 'moodlecourseid' => $id]);
+                    ['sessionid' => $sessionid, 'userid' => $userid, 'moodlecourseid' => $cmi5launch->id]);
 
                 // Add row data.
                 $rowdata["Attempt"] = get_string('cmi5launchattemptrow', 'cmi5launch') . $attempt;
@@ -232,24 +233,6 @@ foreach ($auids as $key => $auid) {
                     $scorerow[get_string('cmi5launchattemptrow', 'cmi5launch')
                     . $attempt] = is_numeric($usersession->score) ? number_format((float)$usersession->score, 2) : '';
                 }
-                switch ($gradetype) {
-
-                    // GRADE_AUS_CMI5 = 0.
-                    // GRADE_HIGHEST_CMI5 = 1.
-                    // GRADE_AVERAGE_CMI5 =  2.
-                    // GRADE_SUM_CMI5 = 3.
-
-                    case 1:
-                        $grade = get_string('cmi5launchsessiongradehigh', 'cmi5launch');
-                        $overall = max($sessionscores);
-                        break;
-                    case 2:
-                        $grade = get_string('cmi5launchsessiongradeaverage', 'cmi5launch');
-                        $overall = (array_sum($sessionscores) / count($sessionscores));
-                        break;
-                }
-
-                $scorerow["Grading type"] = $grade;
 
                 $attempt++;
 
@@ -266,6 +249,32 @@ foreach ($auids as $key => $auid) {
     } // End else from aurecord if.
 } // End of for each auids.
 
+// Calculate overall grade based on grade type.
+// GRADE_AUS_CMI5 = 0, GRADE_HIGHEST_CMI5 = 1, GRADE_AVERAGE_CMI5 = 2, GRADE_SUM_CMI5 = 3.
+$grade = '';
+$overall = null;
+if (!empty($sessionscores)) {
+    switch ($gradetype) {
+        case 0:
+            $grade = get_string('cmi5launchsessiongradeaus', 'cmi5launch');
+            $overall = end($sessionscores);
+            break;
+        case 1:
+            $grade = get_string('cmi5launchsessiongradehigh', 'cmi5launch');
+            $overall = max($sessionscores);
+            break;
+        case 2:
+            $grade = get_string('cmi5launchsessiongradeaverage', 'cmi5launch');
+            $overall = (array_sum($sessionscores) / count($sessionscores));
+            break;
+        case 3:
+            $grade = get_string('cmi5launchsessiongradesum', 'cmi5launch');
+            $overall = array_sum($sessionscores);
+            break;
+    }
+}
+$scorerow["Grading type"] = $grade;
+
 // Display the grading type, highest, avg, etc.
 $scorecolumns[] = 'Grading type';
 $scoreheaders[] = 'Grading type';
@@ -274,7 +283,6 @@ $scoreheaders[] = 'Overall Score';
 
 // Session score may be null or empty.
 if (!empty($sessionscores)) {
-
     $scorerow["Overall Score"] = isset($overall) && is_numeric($overall) ? number_format((float)$overall, 2) : '';
 } else {
     $scorerow["Overall Score"] = '';

--- a/settings.php
+++ b/settings.php
@@ -32,6 +32,9 @@
 defined(constant_name: 'MOODLE_INTERNAL') || die();
 
 require_once($CFG->dirroot . '/mod/cmi5launch/constants.php');
+// Required so the updatedcallback functions (e.g. cmi5launch_grade_item_force_regrading)
+// are available when Moodle calls them after saving settings.
+require_once($CFG->dirroot . '/mod/cmi5launch/lib.php');
 
 
 // Class for connecting to CMI5 player grades.
@@ -223,13 +226,17 @@ if ($ADMIN->fulltree) {
 
     // Default grade settings.
     $settings->add(new admin_setting_heading('cmi5launch/gradesettings', get_string('defaultgradesettings', 'cmi5launch'), ''));
-    $settings->add(new admin_setting_configselect(
+    $grademethodsetting = new admin_setting_configselect(
         'cmi5launch/grademethod',
         get_string('grademethod', 'cmi5launch'),
         get_string('grademethoddesc', 'cmi5launch'),
         MOD_CMI5LAUNCH_GRADE_HIGHEST,
         $getgradearray()
-    ));
+    );
+    // When grademethod changes, mark all grade items for recalculation so
+    // Moodle's native gradebook shows updated grades on the next view.
+    $grademethodsetting->set_updatedcallback('cmi5launch_grade_item_force_regrading');
+    $settings->add($grademethodsetting);
 
     for ($i = 0; $i <= 100; $i++) {
         $grades[$i] = "$i";

--- a/view.php
+++ b/view.php
@@ -344,11 +344,11 @@ try {
         if ($au->sessions !== null) {
             // AU has been attempted.
 
-            if ($au->grade !== null && is_numeric($au->grade) && $austatus !== "Satisfied") {
-                // If numeric grade exists, even if 0, display it.
+            if ($au->grade !== null && is_numeric($au->grade) && ($austatus !== "Satisfied" || $grade > 0)) {
+                // Show grade if it exists, unless AU is satisfied with a 0 (avoid misleading zero display).
                 $auinfo[] = $grade;
             } else {
-                // Grade missing despite attempt, leave blank.
+                // Grade missing, or satisfied with 0 — leave blank.
                 $auinfo[] = " ";
             }
 


### PR DESCRIPTION
A couple of updates and changes. Average vs highest grades wasn't working as it should. 
**classes/local/grade_helpers.php**
cmi5launch_check_user_grades_for_updates: 
Fixed returning a non-numeric value (Exception object or error array) when a user has no record or an error occurs. Now returns null so Moodle shows a blank grade instead of "error".

cmi5launch_update_au_for_user_grades:
Fixed $overallgrade being overwritten on every loop iteration for multi-AU courses — only the last AU's grade was being reported. Now collects all AU grades into $augrades[] and computes the overall grade after the loop using the grademethod. Also moved $gradetype outside the loop.

**lib.php**
cmi5launch_grade_item_update: 
Fixed $params['gradetype'] being set to the CMI5 grade method constant (1=highest, 2=average). When "average" was selected, Moodle received 2 = GRADE_TYPE_SCALE, causing errors and wrong scores. Now always passes GRADE_TYPE_VALUE.

cmi5launch_update_grades (else branch):
Fixed the userid=0 branch — it was calling cmi5launch_grade_item_update with no grades, doing nothing useful. Now iterates all enrolled users and pushes each grade.

cmi5launch_get_user_grades and cmi5launch_update_grades: 
Removed required_param('id', PARAM_INT) dependency. Both functions now derive the course module via get_coursemodule_from_instance(), so they work when called by Moodle's grade framework (which has no URL id param).

cmi5launch_grade_item_force_regrading (new): 
When grademethod changes in admin settings, immediately recalculates grades for all enrolled users across all cmi5launch instances using stored session scores from ausgrades (no LRS/player API calls) and pushes results directly to Moodle's gradebook.

**view.php**
Fixed grade not displaying for satisfied AUs with a real score. The condition $austatus !== "Satisfied" was blocking all grades when satisfied. Changed to ($austatus !== "Satisfied" || $grade > 0) — satisfied AUs with score > 0 now display correctly; satisfied AUs with 0 stay blank.
session_report.php

Fixed per-session score not showing. The $usersession DB query used moodlecourseid => $id (the course module ID from the URL) but sessions are stored with moodlecourseid = $cmi5launch->id (the activity instance ID). Changed to $cmi5launch->id.
grade.php

Fixed the teacher grade update loop passing $cm instead of $cmi5launch to cmi5launch_update_grades. This was the root cause of the "two of the course reported" bug — $cm->id was being used as the iteminstance in grade_update, creating a duplicate grade item alongside the correct one created by view.php.
report.php

Changed $updategrades($user) calls to cmi5launch_update_grades($cmi5launch, $user->id) so that opening the plugin's grade report also pushes updated grades to Moodle's gradebook, not just to the plugin's own DB records.
settings.php

Added require_once lib.php so callback functions are available when Moodle saves admin settings.
Added set_updatedcallback('cmi5launch_grade_item_force_regrading') to the grademethod setting so Moodle's native gradebook reflects the new grading type immediately after saving, without requiring a teacher to navigate through the plugin first.