### PR TITLE
Fix missing and mistyped language strings

### DIFF
--- a/classes/local/cmi5_connectors.php
+++ b/classes/local/cmi5_connectors.php
@@ -369,7 +369,7 @@ class cmi5_connectors {
                 throw new playerException(get_string('cmi5launchtokenerror', 'cmi5launch'));
             }
         } catch (\Throwable $e){
-            throw new playerException(get_string('cmi5launchtokenuncaughtterror', 'cmi5launch'). $e);
+            throw new playerException(get_string('cmi5launchtokenuncaughterror', 'cmi5launch'). $e);
         }
     }
 

--- a/lang/en/cmi5launch.php
+++ b/lang/en/cmi5launch.php
@@ -35,6 +35,7 @@ defined('MOODLE_INTERNAL') || die();
 $string['modulename'] = 'cmi5 launch link';
 $string['modulenameplural'] = 'cmi5 launch links';
 $string['modulename_help'] = 'A plug in for Moodle that allows the launch of cmi5 (xAPI) content which is then tracked to a separate LRS.';
+$string['nocmi5launchs'] = 'There are no cmi5 launch links in this course.';
 
 // Start Default LRS Admin Settings.
 // Header.


### PR DESCRIPTION
Refs #72.

Two of the missing-string references in the issue resolve to live code paths:

1. **`nocmi5launchs`** - `index.php` shows `notice(get_string('nocmi5launchs', 'cmi5launch'))` when a course has no cmi5 launch links, but the string was never defined, so it rendered as the raw `[[nocmi5launchs]]`. Added it (worded to match `modulenameplural`).

2. **`cmi5launchtokenuncaughtterror`** - `classes/local/cmi5_connectors.php:372` called `get_string()` with a double-`t` (`uncaughtterror`). The defined string is `cmi5launchtokenuncaughterror` (single `t`), matching the five other `*uncaughterror` strings used elsewhere in the same file (tenant, registration, url, sessioninfo). This was the only site with the typo, so it rendered the raw key instead of the existing "Uncaught error retrieving the tenant token." message. Fixed the call to use the existing string rather than adding a duplicate.

I intentionally left out `masteryoverride` / `masteryoverridedesc`: those are only referenced inside a commented-out `admin_setting_configselect` block in `settings.php` ("Not sure if we want to implement mastery override at this time"), so they are not rendered. They can be added if/when that setting is enabled.

Verified by grep that both references now resolve and that no `uncaughtterror` (double-t) occurrences remain. I do not have a local Moodle install to run the lang string checker, but both changes match the file's existing format.